### PR TITLE
Fix quick reply crash

### DIFF
--- a/src/message/quickReply.js
+++ b/src/message/quickReply.js
@@ -23,7 +23,7 @@ export class TextQuickReply extends QuickReply {
     constructor(title, payload) {
         super('text');
         this.setTitle(title);
-        this.setPayload(payload);
+        this.setPayload(payload || title);
         return this;
     }
 

--- a/test/message/quickReply.test.js
+++ b/test/message/quickReply.test.js
@@ -21,3 +21,15 @@ test('TextQuickReply', (expect) => {
     }, 'should have the correct structure');
     expect.end();
 });
+
+test('TextQuickReply - without custom Payload', (expect) => {
+    const testReply = new TextQuickReply('Red')
+        .setImageUrl('http://davidsfantastichats.com/img/red.png');
+    expect.same(testReply, {
+        content_type: 'text',
+        title: 'Red',
+        payload: 'Red',
+        image_url: 'http://davidsfantastichats.com/img/red.png',
+    }, 'should have the correct structure');
+    expect.end();
+});


### PR DESCRIPTION
As per readme, I tried to implement the quickReply but it crashed on a rather interesting error:
```
Error: validate.isString: missing parameter - argument to validate
```

It seemed the quickReply required an extra param, the payload to be defined. As I kinda liked the style that the readme went with; I just added a fallback. So it will use the payload when given and fallback to the title when not.

Hope you like it & nice work!